### PR TITLE
Fix navigation menu style

### DIFF
--- a/_sass/modules/_m-navigation-main.scss
+++ b/_sass/modules/_m-navigation-main.scss
@@ -68,7 +68,7 @@
 }
 
 .navigation {
-  position: absolute;
+  position: fixed;
   z-index: 1001;
   width: 17.5rem;
   height: 100%;


### PR DESCRIPTION
In Firefox, the open navigation menu would be visible only partially,
or, depending on the scroll position, not visible at all.

This fixes the issue by changing the `navigation` class to have
`position: fixed` instead of `position: absolute`.